### PR TITLE
the_ocamlspot.vim:fix get syntastic_loclist

### DIFF
--- a/autoload/the_ocamlspot.vim
+++ b/autoload/the_ocamlspot.vim
@@ -27,7 +27,7 @@ function! the_ocamlspot#auto_type()
   if g:the_ocamlspot_auto_type_always
     call the_ocamlspot#main('type')
   else
-    let allerrors = getqflist() + getloclist(0) + get(b:, 'syntastic_loclist', [])
+    let allerrors = getqflist() + getloclist(0) + s:get_syntastic_loclist()
     let current_line = line('.')
     let on_line = filter(copy(allerrors), 'v:val.lnum == ' . current_line)
     if len(on_line) == 0
@@ -275,3 +275,7 @@ function! s:balloon_buffer_cursor()
   return [bufname(v:beval_bufnr), v:beval_lnum, v:beval_col - 1]
 endfunction
 
+function! s:get_syntastic_loclist()
+  let locObj = get(b:, 'syntastic_loclist', [])
+  return type(locObj) ==# type([]) ? locObj : locObj.toRaw()
+endfunction


### PR DESCRIPTION
syntasticを使っていると以下のエラーが出たため対応しました。

```
E745: Using a List as a Number
```

https://github.com/scrooloose/syntastic/commit/8f4695c6de157327efc07c25a3f59de0739b9a1c
この変更で`syntastic_loclist`がリストから辞書に変わったため、`+`演算に失敗していた模様です。
